### PR TITLE
Notify when previous/next stack is empty

### DIFF
--- a/lua/nap.lua
+++ b/lua/nap.lua
@@ -26,6 +26,8 @@ local exec_last = function(norp)
 		call(_next)
 	elseif not norp and _prev ~= nil then
 		call(_prev)
+	else
+		vim.notify(string.format('[nap.nvim] %s stack is empty.', norp and 'Next' or 'Previous'), vim.log.levels.WARN)
 	end
 end
 


### PR DESCRIPTION
Personally, I like feedback when pressing keys.

This would happen rarely if the plugin is used, but I still it's a nice feature.

Maybe a way to disable/configure it through the `setup` func would be useful too, what do you think?

Btw, thanks for the plugin, it's a boiled-down version with the things that I used from the `unimpaired` plugin. 🚀 