### PR TITLE
Fix typo for "lfirst" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ operators = {
     },
     ["L"] = {
         next = { command = "llast", desc = "Last loclist item", },
-        prev = { command = "lfist", desc = "First loclist item" },
+        prev = { command = "lfirst", desc = "First loclist item" },
     },
     ["<C-l>"] = {
         next = { command = "lnfile", desc = "Next loclist item in different file", },

--- a/README_cn.md
+++ b/README_cn.md
@@ -85,7 +85,7 @@ operators = {
     },
     ["L"] = {
         next = { command = "llast", desc = "Last loclist item", },
-        prev = { command = "lfist", desc = "First loclist item" },
+        prev = { command = "lfirst", desc = "First loclist item" },
     },
     ["<C-l>"] = {
         next = { command = "lnfile", desc = "Next loclist item in different file", },

--- a/doc/nap.txt
+++ b/doc/nap.txt
@@ -100,7 +100,7 @@ Expand to see how they are defined. ~
         },
         ["L"] = {
             next = { command = "llast", desc = "Last loclist item", },
-            prev = { command = "lfist", desc = "First loclist item" },
+            prev = { command = "lfirst", desc = "First loclist item" },
         },
         ["<C-l>"] = {
             next = { command = "lnfile", desc = "Next loclist item in different file", },

--- a/lua/nap.lua
+++ b/lua/nap.lua
@@ -241,7 +241,7 @@ M.defaults = {
     },
     ["L"] = {
       next = { command = "llast", desc = "Last loclist item", },
-      prev = { command = "lfist", desc = "First loclist item" },
+      prev = { command = "lfirst", desc = "First loclist item" },
     },
     ["<C-l>"] = {
       next = { command = "lnfile", desc = "Next loclist item in different file", },


### PR DESCRIPTION
Greetings. It's just a typo fix for the "First loclist item" operation: `lfist` -> `lfirst`. So the command can work properly